### PR TITLE
allow https

### DIFF
--- a/src/embed/Js.hx
+++ b/src/embed/Js.hx
@@ -14,7 +14,7 @@ class Js {
 
     switch url.scheme {
       case 'http': 
-      case 'https': throw 'https not supported';
+      case 'https': 
       case v: 'Unsupported scheme in $url';
     }
 


### PR DESCRIPTION
Is there still something preventing embed-js from allowing https now?
